### PR TITLE
Remove 15min.lt ads whitelisting

### DIFF
--- a/easylistlithuania.txt
+++ b/easylistlithuania.txt
@@ -49,7 +49,6 @@
 7min.lt##A[href="http://1920x1080wallpapers.eu/"]
 7min.lt##A[href="http://www.tvlietuviskai.eu/"]
 @@|http://skelbimai.one.lt/uploads/modules/ads/
-@@||15minlt.adocean.pl^$third-party
 @@||9menesiai.lt/image/cache/data/Baneriai/
 @@||apatinukai.lt/image/cache/data/baneriai/
 @@||banners.adnet.lt/i/euro_1_490x270_3.swf


### PR DESCRIPTION
Puslapyje 15min.lt fone rodomos reklamos dėl šio įrašo. Bendrajame easylist'e blokuojamas visas adocean.pl.

Ar yra kokių nors priežasčių whitelistinti šį reklamų tiekėją?